### PR TITLE
Fix .path->.source

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub const pkg = std.build.Pkg{
     .name = "luajit",
-    .path = .{ .path = thisDir() ++ "/src/main.zig" },
+    .source = .{ .path = thisDir() ++ "/src/main.zig" },
     .dependencies = null,
 };
 


### PR DESCRIPTION
.path got updated to .source in zig/build.zig.

https://github.com/ziglang/zig/blob/cff5d9c805aa3433cc2562c3cb29bd3201817214/lib/std/build.zig#L1349-L1353

This PR fixes it here. 